### PR TITLE
Fix typo in component documentation

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -32,7 +32,7 @@ export class HelloComponent extends Component {
 }
 ```
 
-In the example above, _this.run_ fires a local event. _this.run_ fires a global event.
+In the example above, _this.run_ fires a local event. _app.run_ fires a global event.
 
 ## Routing Event
 


### PR DESCRIPTION
Fix typo relating to `this.run` vs `app.run`. `app.run` fires a global event.