### PR TITLE
Feature/404 route

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,6 +1,6 @@
-import app from '../src/apprun';
+import app, { ROUTER_EVENT } from '../src/apprun';
 
-app.on('//', route => {
+app.on(ROUTER_EVENT, route => {
   const menus = document.querySelectorAll('.navbar-nav li');
   for (let i = 0; i < menus.length; ++i) menus[i].classList.remove('active');
   const item = document.querySelector(`[href='${route}']`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,12 +11,12 @@ export class App {
     this._events = {};
   }
 
-  on(name: string, fn: (...args) => void, options: any = {}) {
+  on(name: string, fn: (...args) => void, options: any = {}): void {
     this._events[name] = this._events[name] || [];
     this._events[name].push({ fn: fn, options: options });
   }
 
-  off(name: string, fn: (...args) => void) {
+  off(name: string, fn: (...args) => void): void {
     let subscribers = this._events[name];
     if (subscribers) {
       subscribers = subscribers.filter((sub) => sub.fn !== fn);
@@ -25,7 +25,7 @@ export class App {
     }
   }
 
-  run(name: string, ...args) {
+  run(name: string, ...args): number {
     let subscribers = this._events[name];
     console.assert(!!subscribers, 'No subscriber for event: ' + name);
     if (subscribers) {
@@ -41,13 +41,15 @@ export class App {
       if (subscribers.length) this._events[name] = subscribers;
       else delete this._events[name]
     }
+
+    return subscribers ? subscribers.length : 0;
   }
 
-  once(name: string, fn, options: any = {}) {
+  once(name: string, fn, options: any = {}): void {
     this.on(name, fn, { ...options, once: true });
   }
 
-  private delay(name, fn, args, options) {
+  private delay(name, fn, args, options): void {
     if (options._t) clearTimeout(options._t);
     options._t = setTimeout(() => {
       clearTimeout(options._t);

--- a/src/apprun.ts
+++ b/src/apprun.ts
@@ -3,7 +3,9 @@ import { createElement, render, Fragment } from './vdom';
 import { Component } from './component';
 import { VNode, View, Action, Update } from './types';
 import { on, update } from './decorator';
-import route from './router';
+import route, { ROUTER_EVENT, ROUTER_404_EVENT } from './router';
+
+export { ROUTER_EVENT, ROUTER_404_EVENT } from './router';
 
 export interface IApp {
   start<T>(element?: Element | string, model?: T, view?: View<T>, update?: Update<T>,
@@ -31,7 +33,7 @@ app.start = <T>(element?: HTMLElement | string, model?: T,  view?: View<T>, upda
 
 if (!app['route']) {
   app['route'] = route;
-  app.on('//', _ => { });
+  app.on(ROUTER_EVENT, _ => { });
   app.on('#', _ => { });
   app.on('route', url => route(url));
   if (typeof document === 'object') {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,19 +1,20 @@
 import app from './app';
 
-const ROUTER_EVENT = '//';
+const ROUTER_EVENT: string = '//';
+const ROUTER_404_EVENT: string = '///';
 
 export default function route(url: string) {
   if (!url) url = '#';
   if (url.startsWith('#')) {
     const [name, ...rest] = url.split('/');
-    app.run(name, ...rest);
+    app.run(name, ...rest) || app.run(ROUTER_404_EVENT, name, ...rest);
     app.run(ROUTER_EVENT, name, ...rest);
   } else if (url.startsWith('/')) {
     const [_, name, ...rest] = url.split('/');
-    app.run('/' + name, ...rest);
+    app.run('/' + name, ...rest) || app.run(ROUTER_404_EVENT, '/' + name, ...rest);
     app.run(ROUTER_EVENT, '/' + name, ...rest);
   } else {
-    app.run(url);
+    app.run(url) || app.run(ROUTER_404_EVENT, url);
     app.run(ROUTER_EVENT, url);
   }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,7 @@
 import app from './app';
 
-const ROUTER_EVENT: string = '//';
-const ROUTER_404_EVENT: string = '///';
+export const ROUTER_EVENT: string = '//';
+export const ROUTER_404_EVENT: string = '///';
 
 export default function route(url: string) {
   if (!url) url = '#';

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -109,7 +109,6 @@ describe('app events', () => {
     expect(console.assert).toHaveBeenCalled();
   });
 
-
   it('should run only once', () => {
     const app = new App();
     spyOn(console, 'assert');
@@ -119,4 +118,21 @@ describe('app events', () => {
     expect(console.assert).toHaveBeenCalled();
   });
 
+  it('should return the number of subscribers for a valid event name', () => {
+    const app = new App();
+    const hello = () => {};
+    app.on('hello', hello);
+    debugger;
+    const subs: number = app.run('hello');
+    expect(subs).toBe(1);
+    app.off('hello', hello);
+  });
+
+  it('should return 0 subscribers for an invalid event name', () => {
+    const app = new App();
+    spyOn(console, 'assert');
+    const subs: number = app.run('hiiiiiiii');
+    expect(console.assert).toHaveBeenCalled();
+    expect(subs).toBe(0);
+  });
 });

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -1,8 +1,5 @@
 import app from '../src/apprun';
-import route from '../src/router';
-
-const ROUTER_EVENT: string = '//';
-const ROUTER_404_EVENT: string = '///';
+import route, { ROUTER_EVENT, ROUTER_404_EVENT } from '../src/router';
 
 describe('router', () => {
 

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -1,6 +1,9 @@
 import app from '../src/apprun';
 import route from '../src/router';
 
+const ROUTER_EVENT: string = '//';
+const ROUTER_404_EVENT: string = '///';
+
 describe('router', () => {
 
   beforeAll(() => {
@@ -9,7 +12,7 @@ describe('router', () => {
 
   it('should not fire event if not initialize', () => {
     const fn = jasmine.createSpy('fn');
-    app.on('//', fn);
+    app.on(ROUTER_EVENT, fn);
     expect(fn).not.toHaveBeenCalled();
   });
 
@@ -17,7 +20,7 @@ describe('router', () => {
     const fn1 = jasmine.createSpy('fn1');
     const fn2 = jasmine.createSpy('fn2');
     app.on('#', fn1);
-    app.on('//', fn2);
+    app.on(ROUTER_EVENT, fn2);
     route('');
     expect(fn1).toHaveBeenCalledWith();
     expect(fn2).toHaveBeenCalledWith('#');
@@ -27,7 +30,7 @@ describe('router', () => {
     const fn3 = jasmine.createSpy('fn3');
     const fn4 = jasmine.createSpy('fn4');
     app.on('#x', fn3);
-    app.on('//', fn4);
+    app.on(ROUTER_EVENT, fn4);
     document.location.href = '#x';
     setTimeout(() => {
       expect(fn3).toHaveBeenCalledWith();
@@ -40,7 +43,7 @@ describe('router', () => {
     const fn1 = jasmine.createSpy('fn1');
     const fn2 = jasmine.createSpy('fn2');
     app.on('/home', fn1);
-    app.on('//', fn2);
+    app.on(ROUTER_EVENT, fn2);
     app.run('route', '/home');
     expect(fn1).toHaveBeenCalledWith();
     expect(fn2).toHaveBeenCalledWith('/home');
@@ -50,7 +53,7 @@ describe('router', () => {
     const fn1 = jasmine.createSpy('fn1');
     const fn2 = jasmine.createSpy('fn2');
     app.on('/x', fn1);
-    app.on('//', fn2);
+    app.on(ROUTER_EVENT, fn2);
     app.run('route', '/x/y/z');
     expect(fn1).toHaveBeenCalledWith('y', 'z');
     expect(fn2).toHaveBeenCalledWith('/x', 'y', 'z');
@@ -66,4 +69,117 @@ describe('router', () => {
     expect(fn2).toHaveBeenCalled();
   });
 
+  it('should not invoke a default route handler if there is an event handler for # based URI', () => {
+    const fn1 = jasmine.createSpy('fn1');
+    const fn2 = jasmine.createSpy('fn2');
+    const fn3 = jasmine.createSpy('fn3');
+
+    app.on(ROUTER_EVENT, fn1);
+    app.on(ROUTER_404_EVENT, fn2);
+    app.on('#foo', fn3);
+
+    app.run('route', '#foo');
+
+    expect(fn1).toHaveBeenCalledWith('#foo');
+    expect(fn2).not.toHaveBeenCalled();
+    expect(fn3).toHaveBeenCalled();
+
+    app.off(ROUTER_EVENT, fn1);
+    app.off(ROUTER_404_EVENT, fn2);
+    app.off('#foo', fn3);
+  });
+
+  it('should not invoke a default route handler if there is an event handler for / based URI', () => {
+    const fn1 = jasmine.createSpy('fn1');
+    const fn2 = jasmine.createSpy('fn2');
+    const fn3 = jasmine.createSpy('fn3');
+
+    app.on(ROUTER_EVENT, fn1);
+    app.on(ROUTER_404_EVENT, fn2);
+    app.on('/foo', fn3);
+
+    app.run('route', '/foo');
+
+    expect(fn1).toHaveBeenCalledWith('/foo');
+    expect(fn2).not.toHaveBeenCalledWith('/foo');
+    expect(fn3).toHaveBeenCalled();
+
+    app.off(ROUTER_EVENT, fn1);
+    app.off(ROUTER_404_EVENT, fn2);
+    app.off('/foo', fn3);
+  });
+
+  it('should not invoke a default route handler if there is an event handler for a non # or / based URI', () => {
+    const fn1 = jasmine.createSpy('fn1');
+    const fn2 = jasmine.createSpy('fn2');
+    const fn3 = jasmine.createSpy('fn3');
+
+    app.on(ROUTER_EVENT, fn1);
+    app.on(ROUTER_404_EVENT, fn2);
+    app.on('foo', fn3);
+
+    app.run('route', 'foo');
+
+    expect(fn1).toHaveBeenCalledWith('foo');
+    expect(fn2).not.toHaveBeenCalledWith('foo');
+    expect(fn3).toHaveBeenCalled();
+
+    app.off(ROUTER_EVENT, fn1);
+    app.off(ROUTER_404_EVENT, fn2);
+    app.off('foo', fn3);
+  });
+
+  it('should invoke a default route handler if there is no event handler for # based URI', () => {
+    const fn1 = jasmine.createSpy('fn1');
+    const fn2 = jasmine.createSpy('fn2');
+    spyOn(console, 'assert');
+
+    app.on(ROUTER_EVENT, fn1);
+    app.on(ROUTER_404_EVENT, fn2);
+
+    app.run('route', '#foo');
+
+    expect(fn1).toHaveBeenCalledWith('#foo');
+    expect(fn2).toHaveBeenCalledWith('#foo');
+    expect(console.assert).toHaveBeenCalled();
+
+    app.off(ROUTER_EVENT, fn1);
+    app.off(ROUTER_404_EVENT, fn2);
+  });
+
+  it('should invoke a default route handler if there is no event handler for / based URI', () => {
+    const fn1 = jasmine.createSpy('fn1');
+    const fn2 = jasmine.createSpy('fn2');
+    spyOn(console, 'assert');
+
+    app.on(ROUTER_EVENT, fn1);
+    app.on(ROUTER_404_EVENT, fn2);
+
+    app.run('route', '/foo');
+
+    expect(fn1).toHaveBeenCalledWith('/foo');
+    expect(fn2).toHaveBeenCalledWith('/foo');
+    expect(console.assert).toHaveBeenCalled();
+
+    app.off(ROUTER_EVENT, fn1);
+    app.off(ROUTER_404_EVENT, fn2);
+  });
+
+  it('should invoke a default route handler if there is no event handler for a non # or / based URI', () => {
+    const fn1 = jasmine.createSpy('fn1');
+    const fn2 = jasmine.createSpy('fn2');
+    spyOn(console, 'assert');
+
+    app.on(ROUTER_EVENT, fn1);
+    app.on(ROUTER_404_EVENT, fn2);
+
+    app.run('route', 'foo/fred');
+
+    expect(fn1).toHaveBeenCalledWith('foo/fred');
+    expect(fn2).toHaveBeenCalledWith('foo/fred');
+    expect(console.assert).toHaveBeenCalled();
+    
+    app.off(ROUTER_EVENT, fn1);
+    app.off(ROUTER_404_EVENT, fn2);
+  });
 });


### PR DESCRIPTION
Users can now bind an event handler to catch otherwise unhandled URI routes using:

import app, { ROUTER_404_EVENT} from 'apprun';
app.on(ROUTER_404_EVENT, () => { console.log('No route handler'); });

Fixes #46.

Changes:
- app.run now returns number of subscribers.
- app.route now calls app.run(ROUTER_404_EVENT, ...) if there were no subscribers for the URI.
- ROUTER_EVENT and ROUTER_404_EVENT constants are now exported from apprun.ts.
- add tests for changes.