### PR TITLE
Improve updateProps for data-*, role, and class attributes

### DIFF
--- a/src/vdom-my.ts
+++ b/src/vdom-my.ts
@@ -145,10 +145,10 @@ function create(node: VNode | string, isSvg = false): Element {
   return element
 }
 
-function mergeProps(a: {}, b: {}): {} {
+function mergeProps(oldProps: {}, newProps: {}): {} {
   const props = {};
-  if (a) Object.keys(a).forEach(p => props[p] = '');
-  if (b) Object.keys(b).forEach(p => props[p] = b[p]);
+  if (oldProps) Object.keys(oldProps).forEach(p => props[p] = null);
+  if (newProps) Object.keys(newProps).forEach(p => props[p] = newProps[p]);
   return props;
 }
 
@@ -171,14 +171,26 @@ function updateProps(element: Element, props: {}) {
     } else if (name.startsWith('data-')) {
       const dname = name.substring(5);
       const cname = dname.replace(/-(\w)/g, (match) => match[1].toUpperCase());
-      if (element.dataset[cname] !== value) element.dataset[cname] = value;
+      if (element.dataset[cname] !== value) {
+        if(value || value === "") element.dataset[cname] = value;
+        else delete element.dataset[cname];
+      }
     } else if (element instanceof SVGElement ||
       name.startsWith("role") || name.indexOf("-")>=0) {
       if (name === 'className') name = 'class';
-      if (element.getAttribute(name) !== value) element.setAttribute(name, value)
+      if (element.getAttribute(name) !== value) {
+        if(value) element.setAttribute(name, value);
+        else element.removeAttribute(name);
+      }
     } else {
       if (name === 'class') name = 'className';
-      if (element[name] !== value) element[name] = value;
+      if (element[name] !== value) {
+        if(value) element[name] = value;
+        else {
+          if (name === 'className') name = 'class';
+          element.removeAttribute(name);
+        }
+      }
       if (name === 'key' && value) keyCache[value] = element;
     }
   }

--- a/tests/data-attr.spec.tsx
+++ b/tests/data-attr.spec.tsx
@@ -1,15 +1,23 @@
 import app from '../src/apprun';
 
-describe('vdom-my', () => {
-  it('should set data attribute', () => {
-    const el = document.createElement('div');
-    const view = () => <div data-a='a'></div>
-    app.render(el, view());
-    const div = el.firstElementChild as HTMLDivElement;
-    expect(div.dataset.a).toBe('a');
-  })
+(expect as any).extend({
+  toBeNullOrEmptyString(received) {
+    if(received === null || received === '') {
+      return { 
+        message: () => 'expected ${received} not to be null or the empty string', 
+        pass: true
+      };
+    } else {
+      return { 
+        message: () => 'expected ${received} to be null or the empty string', 
+        pass: false
+      };
+    }
+  }
+});
 
-  it('should unset data attribute', () => {
+describe('vdom-my', () => {
+  it('should support data attribute', () => {
     const el = document.createElement('div');
     const view1 = () => <div data-a='b'></div>
     const view2 = () => <div></div>
@@ -17,28 +25,20 @@ describe('vdom-my', () => {
     const div = el.firstElementChild as HTMLDivElement;
     expect(div.dataset.a).toBe('b');
     app.render(el, view2());
+    expect(div.dataset.a).toBe(undefined);
+  });
+
+  it('should support a boolean data attribute', () => {
+    const el = document.createElement('div');
+    const view1 = () => <div data-a=''></div>
+    const view2 = () => <div></div>
+    app.render(el, view1());
+    const div = el.firstElementChild as HTMLDivElement;
     expect(div.dataset.a).toBe('');
-  })
-  it('should support attribute - role', () => {
-    const el = document.createElement('div');
-    const view1 = () => <div role='r'></div>
-    const view2 = () => <div></div>
-    app.render(el, view1());
-    const div = el.firstElementChild as HTMLDivElement;
-    expect(div.getAttribute('role')).toBe('r');
     app.render(el, view2());
-    expect(div.getAttribute('role')).toBe('');
-  })
-  it('should support attribute - aria', () => {
-    const el = document.createElement('div');
-    const view1 = () => <div aria-label='al'></div>
-    const view2 = () => <div></div>
-    app.render(el, view1());
-    const div = el.firstElementChild as HTMLDivElement;
-    expect(div.getAttribute('aria-label')).toBe('al');
-    app.render(el, view2());
-    expect(div.getAttribute('aria-label')).toBe('');
-  })
+    expect(div.dataset.a).toBe(undefined);
+  });
+
   it('should support data-kebab-case', () => {
     const el = document.createElement('div');
     const view1 = () => <div data-kebab-case='123'></div>
@@ -47,6 +47,28 @@ describe('vdom-my', () => {
     const div = el.firstElementChild as HTMLDivElement;
     expect(div.getAttribute('data-kebab-case')).toBe('123');
     app.render(el, view2());
-    expect(div.getAttribute('data-kebab-case')).toBe('');
-  })
+    expect(div.hasAttribute('data-kebab-case')).toBe(false);
+  });
+
+  it('should support attribute - role', () => {
+    const el = document.createElement('div');
+    const view1 = () => <div role='r'></div>
+    const view2 = () => <div></div>
+    app.render(el, view1());
+    const div = el.firstElementChild as HTMLDivElement;
+    expect(div.getAttribute('role')).toBe('r');
+    app.render(el, view2());
+    expect(div.hasAttribute('role')).toBe(false);
+  });
+
+  it('should support attribute - aria', () => {
+    const el = document.createElement('div');
+    const view1 = () => <div aria-label='al'></div>
+    const view2 = () => <div></div>
+    app.render(el, view1());
+    const div = el.firstElementChild as HTMLDivElement;
+    expect(div.getAttribute('aria-label')).toBe('al');
+    app.render(el, view2());
+    expect(div.hasAttribute('aria-label')).toBe(false);
+  });
 })

--- a/tests/vdom-my.spec.tsx
+++ b/tests/vdom-my.spec.tsx
@@ -67,7 +67,6 @@ describe('vdom-my', () => {
   });
 
   it('it should update className', () => {
-
     const element = render(createElement('div', { className: 'a' }, 'x'));
     expect(element.className).toEqual('a');
     render(createElement('div', { className: 'a b' }, 'xx'));
@@ -87,6 +86,22 @@ describe('vdom-my', () => {
 
   it('it should reset class and style', () => {
     let element = render(createElement('div', {
+      class: 'a',
+      style: { left: '5px' }
+    }, 'x'));
+    expect(element.nodeName).toEqual('DIV');
+    expect(element.className).toEqual('a');
+    expect(element.textContent).toEqual('x');
+    expect(element.style.left).toEqual('5px');
+    render(createElement("div", null));
+    expect(element.nodeName).toEqual('DIV');
+    expect(element.style.left).toEqual('');
+    expect(element.className).toEqual('');
+    expect(element.textContent).toEqual('');
+  });
+
+  it('it should reset className and style', () => {
+    let element = render(createElement('div', {
       className: 'a',
       style: { left: '5px' }
     }, 'x'));
@@ -95,8 +110,10 @@ describe('vdom-my', () => {
     expect(element.textContent).toEqual('x');
     expect(element.style.left).toEqual('5px');
     render(createElement("div", null));
+    expect(element.nodeName).toEqual('DIV');
     expect(element.style.left).toEqual('');
     expect(element.className).toEqual('');
+    expect(element.textContent).toEqual('');
   });
 
   it('it should flatten children', () => {


### PR DESCRIPTION
This cleans up the data-*, class, and role attributes remaining with no value if they should have been removed when a tag is reused. Fixes #47.
- data-* attributes should be deleted if not used.
- role attribute should have removeAttribute called if not used.
- className should have removeAttribute called if not used.
- add tests