### PR TITLE
Add simple script to debug tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "webpack -p --mode production",
     "test": "jest --watch",
     "jest": "jest",
+    "jest:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "start": "webpack-dev-server --mode development",
     "build:docs": "marked -i docs/README.md -o demo/components/home.html"
   },


### PR DESCRIPTION
I find it easier to debug test cases through a debugger rather than littering log statements. Might as well provide the command I was using.
- Add "npm run jest:debug" to allow simple debugging in test cases. Just add "debugger;" at the appropriate place.