### PR TITLE
create access to the component's root element

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -23,6 +23,7 @@ export class Component<T=any, E=any> {
   public rendered;
   public mounted;
   public unload;
+  public el;
   private tracking_id;
 
   render(element: HTMLElement, node) {

--- a/src/component.ts
+++ b/src/component.ts
@@ -27,6 +27,7 @@ export class Component<T=any, E=any> {
 
   render(element: HTMLElement, node) {
     app.render(element, node, this);
+    this.el = node;
   }
 
   private renderState(state: T) {
@@ -66,6 +67,7 @@ export class Component<T=any, E=any> {
           const { removedNodes, oldValue } = changes[0];
           if (oldValue === this.tracking_id || Array.from(removedNodes).indexOf(el) >=0){
             this.unload();
+            this.el = null;
             observer.disconnect();
           }
         });


### PR DESCRIPTION
For the class that extends Components, you might want to do something after it's rendered. 
In that case, instance needs access to the root element. 
This change is to assign the element and remove the reference when it's done unload to clean up.