### PR TITLE
Fix web-component attributes

### DIFF
--- a/demo/components/web-components.tsx
+++ b/demo/components/web-components.tsx
@@ -1,0 +1,143 @@
+// @ts-nocheck
+
+import { app, Component } from '../../src/apprun'
+
+class MyWebcomp extends Component {
+  css = `section { border: 1px solid #ccc; margin: 0.2em 0; }
+span { display: inline-block; width: 6em }
+button { width: 6em }`
+  state = 0
+  view = (state, props = this.props) => {
+    const { name, value, handleClick } = props
+    return (
+      <>
+        <style innerHTML={this.css} />
+        <section>
+          <span>{name}</span>
+          <button $onclick='inc'>
+            state: {state}
+          </button>
+          {handleClick
+            ? (
+              <button onclick={() => handleClick(10)}>
+                props: {value}
+              </button>
+            )
+            : null
+          }
+        </section>
+      </>
+    )
+  }
+  update = {
+    inc: (state) => {
+      state += 1
+      this.dispatchEvent(new CustomEvent('my-webcomp-inc', {
+        composed: true,
+        bubbles: true,
+        detail: { name: this.props.name, state }
+      }))
+      return state
+    },
+    attributeChanged: (state, name, oldValue, value) => {
+      console.log('attributeChanged', {state, name, oldValue, value})
+    }
+  }
+  mounted = (props) => {
+    this.props = props
+    return this.state
+  }
+}
+
+app.webComponent('my-webcomp', MyWebcomp, {
+  shadow: true,
+  observedAttributes: ['name', 'value', 'handleClick']
+})
+
+// ---- a web-component container for my-webcomp ----
+
+class MyContainer extends HTMLElement {
+  state = 2
+  update = (n) => {
+    this.$state.textContent = this.$el.value = n
+  }
+  handleClick = () => this.update(this.state = 0)
+  connectedCallback () {
+    this.innerHTML = `<div class='box app'>
+      <h4>A Web-Component Container</h4>
+      <button>reset: <span>${this.state}</span></button>
+      <my-webcomp name='name: wc'/>
+    </div>`
+    this.$reset = this.querySelector('button')
+    this.$state = this.querySelector('span')
+    this.$el = this.querySelector('my-webcomp')
+    this.update(this.state)
+    this.$el.handleClick = (n) => this.update(this.state += n)
+    this.$reset.addEventListener('click', this.handleClick)
+  }
+  disconnectedCallback () {
+    this.$reset.removeEventListener('click', this.handleClick)
+  }
+}
+
+customElements.define('my-container', MyContainer)
+
+// ---- a jsx container accessing my-webcomp and listening on custom event ----
+
+class MyJsxContainer extends Component {
+  state = 5
+  view = (state) => (
+    <div className='box jsx' ref={ref => this.attachCustomEvent(ref)}>
+      <h4>A JSX Container</h4>
+      <button onclick={() => this.run('reset') }>reset: {state}</button>
+      <my-webcomp name='name: local' />
+      <my-webcomp name='name: bidir'
+        value={state}
+        handleClick={(n) => this.run('change', n)} />
+    </div>
+  )
+  update = {
+    reset: (state) => 0,
+    change: (state, n) => state + n
+  }
+  unload = () => {
+    this.detachCustomEvent(this.ref)
+  }
+  handleCustomEvent = (ev) => {
+    console.log('handleCustomEvent', ev.detail)
+  }
+  attachCustomEvent = (ref) => {
+    if (this.ref !== ref) {
+      this.detachCustomEvent(this.ref)
+      this.ref = ref
+      this.ref.addEventListener('my-webcomp-inc', this.handleCustomEvent.bind(this))
+    }
+  }
+  detachCustomEvent = (ref) => {
+    ref && ref.removeEventListener('my-webcomp-inc', this.handleCustomEvent.bind(this))
+  }
+}
+
+// ---- the application ----
+
+const style = `html { font-family: sans-serif; }
+.box { margin: 0.5em 0; padding: 0.5em; border: 1px solid #ccc; }
+`
+
+const view = () => (
+  <>
+    <style innerHTML={style} />
+    <div>
+      <h2>Web-Components Demo</h2>
+      <p>This Demo passes properties from a container to the web-component <code>&lt;my-webcomp&gt;</code>.</p>
+      <p>Clicking on "props:" buttons increase the counter in the container, which then passes on the new value back to the component. "state:" changes only the local state</p>
+    </div>
+    <my-container />
+    <MyJsxContainer />
+  </>
+)
+const update = {
+  '#webcomponents': (model) => model
+}
+
+export default element => new Component({}, view, update).mount(element);

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -18,6 +18,7 @@ import hello from './components/hello';
 import svg from './components/svg';
 import animation from './components/animation';
 import play from './components/play';
+import webcomponents from './components/web-components';
 
 const element = document.getElementById('my-app');
-[home, hello, counter, counters, todo, calculator, dragdrop, svg, animation, benchmark, play].forEach(c => c(element));
+[home, hello, counter, counters, todo, calculator, dragdrop, svg, animation, benchmark, play, webcomponents].forEach(c => c(element));

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
                   <li><a href="#animation">Animation</a></li>
                   <li><a href="#svg">SVG</a></li>
                   <li><a href="#todo">Todo - Undo - Redo</a></li>
+                  <li><a href="#webcomponents">Web-Components</a></li>
                   <li role="separator" class="divider"></li>
                   <li><a href="https://github.com/samphilipd/todomvc-apprun">ToDoMVC Example</a></li>
                   <li><a href="https://yysun.github.io/apprun-hn">Hacker News Reader - PWA Example</a></li>

--- a/src/web-component.ts
+++ b/src/web-component.ts
@@ -29,7 +29,7 @@ export const customElement = (componentClass, options: CustomElementOptions = {}
 
       // add getters/ setters to allow observation on observedAttributes
       (opts.observedAttributes || []).forEach(name => {
-        props[name] = this[name];
+        if (this[name] !== undefined) props[name] = this[name];
         Object.defineProperty(this, name, {
           get(): any {
             return props[name];
@@ -48,6 +48,8 @@ export const customElement = (componentClass, options: CustomElementOptions = {}
       this._component = new componentClass({ ...props, children }).mount(this._shadowRoot, opts);
       // attach props to component
       this._component._props = props;
+      // expose dispatchEvent
+      this._component.dispatchEvent = this.dispatchEvent.bind(this)
       if (this._component.mounted) {
         const new_state = this._component.mounted(props, children, this._component.state);
         if (typeof new_state !== 'undefined') this._component.state = new_state;
@@ -67,7 +69,7 @@ export const customElement = (componentClass, options: CustomElementOptions = {}
   attributeChangedCallback(name, oldValue, value) {
     this._component?.run('attributeChanged', name, oldValue, value);
     // store the new property/ attribute
-    this._component._props[name] = value
+    this._component && (this._component._props[name] = value)
     if (value !== oldValue && !(options.render === false)) {
       window.requestAnimationFrame(() => {
         // re-render state with new combined props on next animation frame


### PR DESCRIPTION
PR #91 introduced a regression error as component may be uninitialized in attributeChangedCallback. Sorry for that.

this._component._props may throw therefor in attributeChangedCallback.

Same applies to props added via this.attributes may get overwritten by undefined properties in observedAttributes loop.

Furthermore  dispatchEvent is attached to component to allow passing custom events to other web-components.
    
Finally a demo page was added in Examples which considers passing all the attributes/ properties.

Thanks for this great library. I really like its simplicity. :clap: 