### PR TITLE
Fix broken link in architecture docs to 05-component.md

### DIFF
--- a/docs/04-architecture.md
+++ b/docs/04-architecture.md
@@ -102,4 +102,4 @@ Events can be strongly typed using TypeScript Discriminated Unions. If you are i
 
 ## Event Scope
 
-So far, the AppRun events we see are global events, which means that the events are published and handled globally by all modules. Sometime, you may want to limit the events to a certain scope. You then can use [components](04-component).
+So far, the AppRun events we see are global events, which means that the events are published and handled globally by all modules. Sometime, you may want to limit the events to a certain scope. You then can use [components](05-component).


### PR DESCRIPTION
The link is broken in this docs page: https://apprun.js.org/docs/#/04-architecture#event-scope. When trying to follow link to 05-component.md it fails due to a typo in the md file: 04-component.md

I changed the link to use the correct path in the .md file. (`05-component.md`)